### PR TITLE
Potential fix for code scanning alert no. 8: Insecure randomness

### DIFF
--- a/src/components/LegalAlerts.tsx
+++ b/src/components/LegalAlerts.tsx
@@ -14,6 +14,15 @@ import { toast } from 'sonner@2.0.3';
 import { useSubscription } from '../contexts/SubscriptionContext';
 import { Alert, AlertDescription, AlertTitle } from './ui/alert';
 
+function generateSecretKey(length: number = 16): string {
+  const bytes = new Uint8Array(length);
+  // Use cryptographically secure random values available in the browser
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 interface SearchAlert {
   id: number;
   name: string;
@@ -170,7 +179,7 @@ export function LegalAlerts({ violations = {}, caseDetails = {} }: LegalAlertsPr
         alert_type: 'o',
         date_created: new Date().toISOString(),
         date_last_hit: null,
-        secret_key: Math.random().toString(36).substring(7)
+        secret_key: generateSecretKey()
       };
 
       setSearchAlerts([newAlert, ...searchAlerts]);
@@ -198,7 +207,7 @@ export function LegalAlerts({ violations = {}, caseDetails = {} }: LegalAlertsPr
         alert_type: 1,
         date_created: new Date().toISOString(),
         date_last_hit: null,
-        secret_key: Math.random().toString(36).substring(7),
+        secret_key: generateSecretKey(),
         docket_name: `Docket #${newDocketId}`
       };
 


### PR DESCRIPTION
Potential fix for [https://github.com/FightCPS2023/Cpscaseanalyzerupdated/security/code-scanning/8](https://github.com/FightCPS2023/Cpscaseanalyzerupdated/security/code-scanning/8)

In general, the fix is to stop using `Math.random` to generate values that are (or are likely to be) used as secrets, and instead use a cryptographically secure random generator. In browser-based React code, that means using `crypto.getRandomValues` (or `window.crypto.getRandomValues`) to fill a typed array with random bytes, then encoding those bytes to a string (for example, hex or base64). This avoids predictable sequences and makes brute-force guessing much harder.

For this specific file, the best minimal fix is to introduce a small helper function inside `LegalAlerts.tsx` that creates a random secret token using `crypto.getRandomValues`, and then replace both instances of `Math.random().toString(36).substring(7)` with a call to that helper. The helper can, for example, create a 16‑byte random value and encode it as a hex string (32 hex characters). This maintains the idea of a short string “secret_key” while significantly increasing entropy and eliminating the insecure RNG. No external packages are needed; `crypto.getRandomValues` is built into the browser environment.

Concretely:
- Add a `generateSecretKey` function near the top of `LegalAlerts.tsx` (after the interfaces or before the component definition) that:
  - Creates a `Uint8Array` of a chosen length (e.g., 16).
  - Calls `crypto.getRandomValues(bytes)`.
  - Converts the bytes to a hex string.
- Update:
  - Line 173: `secret_key: Math.random().toString(36).substring(7)` → `secret_key: generateSecretKey()`
  - Line 201: `secret_key: Math.random().toString(36).substring(7),` → `secret_key: generateSecretKey(),`
No imports need to be changed or added since `crypto` is global in the browser context.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
