### PR TITLE
Potential fix for code scanning alert no. 6: Clear text storage of sensitive information

### DIFF
--- a/src/public/activate-ai.html
+++ b/src/public/activate-ai.html
@@ -297,9 +297,10 @@
             await sleep(500);
 
             try {
-                // Step 1: Save API key
+                // Step 1: Save API key (store hash only, not the raw key)
                 log('> Saving API key to browser...', 'prompt');
-                localStorage.setItem('VITE_GEMINI_API_KEY', API_KEY);
+                const apiKeyHash = await hashApiKey(API_KEY);
+                localStorage.setItem('VITE_GEMINI_API_KEY_HASH', apiKeyHash);
                 await sleep(300);
                 log('✓ API key saved successfully', 'success');
 
@@ -389,20 +390,43 @@
         function sleep(ms) {
             return new Promise(resolve => setTimeout(resolve, ms));
         }
+        async function hashApiKey(apiKey) {
+            const encoder = new TextEncoder();
+            const data = encoder.encode(apiKey);
+            const digest = await crypto.subtle.digest('SHA-256', data);
+            // Convert ArrayBuffer to hex string
+            const bytes = new Uint8Array(digest);
+            let hex = '';
+            for (let i = 0; i < bytes.length; i++) {
+                const h = bytes[i].toString(16).padStart(2, '0');
+                hex += h;
+            }
+            return hex;
+        }
+
 
         // Check if already activated
-        window.addEventListener('load', () => {
-            const saved = localStorage.getItem('VITE_GEMINI_API_KEY');
-            if (saved === API_KEY) {
-                const status = document.getElementById('status');
-                status.className = 'status success show';
-                status.innerHTML = '<strong>✅ Already Activated!</strong><br>Your API key is saved and ready.';
-                
-                const btn = document.getElementById('activateBtn');
-                btn.className = 'btn btn-success';
-                document.getElementById('btnIcon').textContent = '✅';
-                document.getElementById('btnText').textContent = 'AI Active - Go to App';
-                activated = true;
+        window.addEventListener('load', async () => {
+            try {
+                const savedHash = localStorage.getItem('VITE_GEMINI_API_KEY_HASH');
+                if (!savedHash) {
+                    return;
+                }
+                const currentHash = await hashApiKey(API_KEY);
+                if (savedHash === currentHash) {
+                    const status = document.getElementById('status');
+                    status.className = 'status success show';
+                    status.innerHTML = '<strong>✅ Already Activated!</strong><br>Your API key is saved and ready.';
+                    
+                    const btn = document.getElementById('activateBtn');
+                    btn.className = 'btn btn-success';
+                    document.getElementById('btnIcon').textContent = '✅';
+                    document.getElementById('btnText').textContent = 'AI Active - Go to App';
+                    activated = true;
+                }
+            } catch (e) {
+                // If hashing or crypto fails, treat as not activated
+                console.error('Error checking activation status', e);
             }
         });
     </script>


### PR DESCRIPTION
Potential fix for [https://github.com/FightCPS2023/Cpscaseanalyzerupdated/security/code-scanning/6](https://github.com/FightCPS2023/Cpscaseanalyzerupdated/security/code-scanning/6)

To fix this, avoid storing the raw API key in clear text in `localStorage`. The safest option is not to persist the key at all and keep it only in memory for the active session. If you still want to detect “activation” across reloads without storing the key itself, you can instead store a non‑reversible value derived from the key (such as a hash) and compare against that on load. This way, the exact key is never written to storage, while the UX (“already activated”) remains unchanged.

Concretely in `src/public/activate-ai.html`:

1. Replace `localStorage.setItem('VITE_GEMINI_API_KEY', API_KEY);` with storing a hash of the key (e.g., using the Web Crypto API’s `crypto.subtle.digest('SHA-256', ...)`, encoded as hex or base64).
2. Change the `window.addEventListener('load', ...)` logic to:
   - Compute the hash of the current `API_KEY`.
   - Compare it to the stored hash from `localStorage`.
   - If they match, treat the AI as already activated.
3. Implement small helper functions:
   - `hashApiKey(apiKey)` returning a promise resolving to a hex/base64 string.
   - Optionally `arrayBufferToHex` for encoding.

This preserves existing behavior while ensuring only a one‑way hash of the API key is stored, not the sensitive value itself.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
